### PR TITLE
Revert "ensure all keymap commands are valid Lua strings"

### DIFF
--- a/lua/direnv.lua
+++ b/lua/direnv.lua
@@ -15,7 +15,7 @@ local function setup_keymaps(keymaps, mode, opts)
    for _, map in ipairs(keymaps) do
       local options =
          vim.tbl_extend("force", { noremap = true, silent = true }, opts or {})
-      vim.api.nvim_set_keymap(mode, map[1], tostring(map[2]), options)
+      vim.api.nvim_set_keymap(mode, map[1], map[2], options)
    end
 end
 


### PR DESCRIPTION
This reverts commit 90f356d4b522552c9f3063f1861c7e672833673d.