### PR TITLE
fix: check if status.state.foundRC equals vim.NIL

### DIFF
--- a/lua/direnv.lua
+++ b/lua/direnv.lua
@@ -142,7 +142,7 @@ M._get_rc_status = function(callback)
          return callback(nil, nil)
       end
 
-      if status.state.foundRC == nil then
+      if status.state.foundRC == vim.NIL then
          cache.status = nil
          cache.path = nil
          cache.last_check = now


### PR DESCRIPTION
When opening nvim in a directory that does not contain a .envrc file, this would throw an error on startup.

This is because `vim.json.decode` translates the json null to `vim.NIL`, which does not match Lua's `nil`