### PR TITLE
feat: allow user to disable default keybindings

### DIFF
--- a/lua/direnv.lua
+++ b/lua/direnv.lua
@@ -447,6 +447,24 @@ end
 --- Setup the plugin with user configuration
 --- @param user_config? table User configuration table
 M.setup = function(user_config)
+   if user_config and user_config.keybindings == true then
+      user_config.keybindings = nil
+   end
+
+   local function check_bind(command)
+      ---@diagnostic disable-next-line: need-check-nil
+      if user_config.keybindings[command] == true then
+         ---@diagnostic disable-next-line: need-check-nil
+         user_config.keybindings[command] = nil
+      end
+   end
+
+   if user_config and user_config.keybindings then
+      for k, _ in pairs(user_config.keybindings) do
+         check_bind(k)
+      end
+   end
+
    M.config = vim.tbl_deep_extend("force", {
       bin = "direnv",
       autoload_direnv = false,


### PR DESCRIPTION
closes: #12 

allows the keybindings option to be set as a `boolean` where `false` means to disable the keybindings and `true` means to keep the defaults. setting it to `true` is always the same as not passing a value at all.

these are a few examples of the new legal configuration values:
```lua
{
  keybindings = false --disable default keybindings
}

{
  keybindings = true --explicitly enable default keybindings. same as not passing it
}

{
  keybindings = {
    allow = false --disable default for specifically `allow`
  }
}

{
  keybindings = {
    allow = false --disable default for specifically `allow`
    deny = false --disable default for specifically `deny`
    reload = true --explicitly enable default for specifically `reload`. same as not passing it
    edit = false --disable default for specifically `edit`
  }
}
```