### PR TITLE
fix: respect configured notification level

### DIFF
--- a/lua/direnv.lua
+++ b/lua/direnv.lua
@@ -81,9 +81,16 @@ end
 --- @param level? integer Log level
 --- @param opts? table Additional notification options
 local function notify(msg, level, opts)
-   -- Ensure level is an integer
-   level = level
-      or (M.config and M.config.notifications.level or vim.log.levels.INFO)
+   local configured_level = M.config
+      and M.config.notifications
+      and M.config.notifications.level
+      or vim.log.levels.INFO
+   level = level or configured_level
+
+   if level < configured_level then
+      return
+   end
+
    opts = opts or {}
    opts = vim.tbl_extend("force", { title = "direnv.nvim" }, opts)
 

--- a/lua/direnv.lua
+++ b/lua/direnv.lua
@@ -82,8 +82,8 @@ end
 --- @param opts? table Additional notification options
 local function notify(msg, level, opts)
    local configured_level = M.config
-      and M.config.notifications
-      and M.config.notifications.level
+         and M.config.notifications
+         and M.config.notifications.level
       or vim.log.levels.INFO
    level = level or configured_level
 


### PR DESCRIPTION
notifications.level was being used only as a default value, not as a severity threshold (which is weird because all calls to notify specify a log level)
This change makes notify() respect the configured level as a minimum threshold, so lower-severity messages are filtered out as expected.