### PR TITLE
fix: statusline error when called before setup

### DIFF
--- a/lua/direnv.lua
+++ b/lua/direnv.lua
@@ -65,11 +65,7 @@ end
 --- @param mode string|table Vim mode for the keymap
 local function setup_keymaps(keymaps, mode)
    for _, map in ipairs(keymaps) do
-      local options = vim.tbl_extend(
-         "force",
-         { noremap = true, silent = true },
-         map[3] or {}
-      )
+      local options = vim.tbl_extend("force", { silent = true }, map[3] or {})
       if map[1] then
          vim.keymap.set(mode, map[1], map[2], options)
       end

--- a/lua/direnv.lua
+++ b/lua/direnv.lua
@@ -204,7 +204,7 @@ M._get_rc_status = function(callback)
    end
 
    vim.system(
-      { M.config.bin, "status", "--json" },
+      { (M.config or {}).bin or "direnv", "status", "--json" },
       { text = true, cwd = cwd },
       on_exit
    )


### PR DESCRIPTION
- **fix: remove deprecated option noremap**
- **fix: crash when statusline() is called before init**

I didn't bother doing it but I think you should define the default config as `M._default_config`
so you can do 

```
local ttl = (M.config or M._default_config).cache_ttl
```

instead of copying the default value whenever you need the option

```
local ttl = (M.config and M.config.cache_ttl) or 5000
```
